### PR TITLE
Add Express server with CORS and task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ npm run build
 ```
 The output will be placed in a `dist` directory ready for deployment.
 
+## Running with Express
+
+After building or during development you can start a small Express server with CORS enabled:
+
+```sh
+npm start
+```
+The server serves the project root and exposes a `/status` endpoint.
+
 ## Features
 
 - Real-time procedurally displaced sphere geometry

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,22 @@
+# Entwicklungsaufgaben
+
+Die folgenden Aufgaben leiten sich aus der Projektbeschreibung ab und dienen als Orientierung für die weitere Implementierung.
+
+## Minimal Viable Product (MVP)
+
+- [ ] Kugelförmigen Planeten als hochauflösende Sphere darstellen
+- [ ] Vertex-Shader implementieren, der mittels fBm-Höhenrelief erzeugt
+- [ ] Fragment-Shader mit Biome-Einfärbung (Temperatur und Feuchtigkeit)
+- [ ] Seed-basierte Generierung für reproduzierbare Planeten hinzufügen
+- [ ] Orbitsteuerung über Maus (OrbitControls)
+- [ ] Prozedurale Shader-Texturen ohne externe Assets verwenden
+- [ ] Express-Server mit CORS-Unterstützung für die Webanwendung bereitstellen
+
+## Erweiterungen
+
+- [ ] Ozean-Shader und variabler Meeresspiegel
+- [ ] Schneekappen bei entsprechenden Klimabedingungen
+- [ ] Markierungen für Städte oder besondere Orte
+- [ ] Echtzeit-Klima-Modell für Jahreszeiten
+- [ ] Export als Heightmap oder Voxelmodell
+- [ ] Rotation und Atmosphärenshell

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Procedural biome planet demo using Three.js and shaders",
   "type": "module",
   "scripts": {
-
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "start": "node server.js"
   },
   "dependencies": {
-    "three": "^0.158.0"
+    "three": "^0.158.0",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const app = express();
+app.use(cors());
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Serve static files from project root (e.g. index.html)
+app.use(express.static(path.join(__dirname)));
+
+app.get('/status', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a small Express server with CORS enabled
- document how to run the server in the README
- list development tasks derived from the project description
- install dependencies for express and cors

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden – network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_684bafb66de4832690efca1611bdae8d