### PR TITLE
Add Vue3 + Vuetify frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProceduralPlanet
 
-ProceduralPlanet is an experimental project focused on generating and rendering planets procedurally using [Three.js](https://threejs.org/). The goal is to explore techniques for terrain creation, atmosphere effects and other visual features entirely through code.
+ProceduralPlanet is an experimental project focused on generating and rendering planets procedurally using [Three.js](https://threejs.org/). The UI is built with [Vue 3](https://vuejs.org/) and [Vuetify](https://vuetifyjs.com/). The goal is to explore techniques for terrain creation, atmosphere effects and other visual features entirely through code.
 
 A detailed project description in German can be found in [docs/Projektbeschreibung.md](docs/Projektbeschreibung.md).
 
@@ -35,7 +35,7 @@ After building or during development you can start a small Express server with C
 ```sh
 npm start
 ```
-The server serves the project root and exposes a `/status` endpoint.
+The server serves the built `dist` directory and exposes a `/status` endpoint.
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -4,12 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Procedural Planet</title>
-  <style>
-    body { margin: 0; overflow: hidden; }
-    canvas { display: block; }
-  </style>
 </head>
 <body>
+  <div id="app"></div>
   <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,10 +11,14 @@
   "dependencies": {
     "three": "^0.158.0",
     "express": "^4.19.2",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "vue": "^3.4.0",
+    "vuetify": "^3.5.0"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^4.5.0",
+    "vite-plugin-vuetify": "^1.0.0"
 
   },
   "author": "",

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Serve static files from project root (e.g. index.html)
-app.use(express.static(path.join(__dirname)));
+app.use(express.static(path.join(__dirname, 'dist')));
 
 app.get('/status', (_req, res) => {
   res.json({ status: 'ok' });

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-app>
+    <PlanetViewer />
+  </v-app>
+</template>
+
+<script setup>
+import PlanetViewer from './components/PlanetViewer.vue';
+</script>

--- a/src/components/PlanetViewer.vue
+++ b/src/components/PlanetViewer.vue
@@ -1,0 +1,133 @@
+<template>
+  <div ref="container" class="viewer"></div>
+</template>
+
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+
+const container = ref(null);
+let renderer, scene, camera, controls, material, animationId;
+
+const vertexShader = `
+uniform float uTime;
+uniform float uElevationScale;
+varying vec3 vPos;
+varying float vElevation;
+
+float noise3(vec3 p){
+  return sin(p.x) * sin(p.y) * sin(p.z);
+}
+
+float fbm(vec3 p){
+  float value = 0.0;
+  float amp = 0.5;
+  for(int i = 0; i < 5; i++){
+    value += amp * noise3(p);
+    p *= 2.0;
+    amp *= 0.5;
+  }
+  return value;
+}
+
+void main(){
+  vec3 nPos = normalize(position);
+  float elevation = fbm(nPos * 5.0 + uTime * 0.1);
+  vPos = nPos;
+  vElevation = elevation;
+  vec3 displaced = nPos * (1.0 + elevation * uElevationScale);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
+}
+`;
+
+const fragmentShader = `
+varying vec3 vPos;
+varying float vElevation;
+uniform float uTime;
+
+vec3 getBiomeColor(float temp, float moist){
+  if(temp < 0.3){
+    if(moist < 0.3) return vec3(0.8,0.8,0.9);
+    return vec3(0.6,0.7,0.8);
+  }
+  if(temp < 0.6){
+    if(moist < 0.3) return vec3(0.8,0.8,0.5);
+    return vec3(0.1,0.6,0.2);
+  }
+  if(moist < 0.5) return vec3(0.9,0.8,0.4);
+  return vec3(0.2,0.7,0.3);
+}
+
+void main(){
+  float temp = clamp((vPos.y + 1.0) / 2.0 + sin(vPos.x * 2.0 + uTime * 0.1) * 0.1, 0.0, 1.0);
+  float moist = clamp(0.5 + sin(vPos.z * 2.0 + uTime * 0.1) * 0.25, 0.0, 1.0);
+  vec3 color = getBiomeColor(temp, moist);
+  if(vElevation < -0.05) color = vec3(0.0, 0.3, 0.8);
+  gl_FragColor = vec4(color, 1.0);
+}
+`;
+
+function init() {
+  const width = container.value.clientWidth;
+  const height = container.value.clientHeight;
+  scene = new THREE.Scene();
+  camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 100);
+  camera.position.set(0,0,3);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(width, height);
+  container.value.appendChild(renderer.domElement);
+
+  const geometry = new THREE.SphereGeometry(1, 256, 256);
+
+  material = new THREE.ShaderMaterial({
+    vertexShader,
+    fragmentShader,
+    uniforms: {
+      uTime: { value: 0 },
+      uElevationScale: { value: 0.15 }
+    }
+  });
+
+  const planet = new THREE.Mesh(geometry, material);
+  scene.add(planet);
+
+  controls = new OrbitControls(camera, renderer.domElement);
+  window.addEventListener('resize', onResize);
+  animate(0);
+}
+
+function onResize() {
+  if(!container.value) return;
+  const width = container.value.clientWidth;
+  const height = container.value.clientHeight;
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+  renderer.setSize(width, height);
+}
+
+function animate(time){
+  material.uniforms.uTime.value = time * 0.001;
+  controls.update();
+  renderer.render(scene, camera);
+  animationId = requestAnimationFrame(animate);
+}
+
+onMounted(init);
+
+onBeforeUnmount(() => {
+  cancelAnimationFrame(animationId);
+  window.removeEventListener('resize', onResize);
+  renderer.dispose();
+});
+</script>
+
+<style scoped>
+.viewer {
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+}
+canvas { display: block; }
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,100 +1,14 @@
-import * as THREE from 'https://unpkg.com/three@0.158.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.158.0/examples/jsm/controls/OrbitControls.js';
+import { createApp } from 'vue';
+import App from './App.vue';
 
-const scene = new THREE.Scene();
-const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 100);
-camera.position.set(0, 0, 3);
+import 'vuetify/styles';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
 
-const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setSize(window.innerWidth, window.innerHeight);
-document.body.appendChild(renderer.domElement);
-
-const geometry = new THREE.SphereGeometry(1, 256, 256);
-
-const vertexShader = `
-uniform float uTime;
-uniform float uElevationScale;
-varying vec3 vPos;
-varying float vElevation;
-
-float noise3(vec3 p){
-  return sin(p.x) * sin(p.y) * sin(p.z);
-}
-
-float fbm(vec3 p){
-  float value = 0.0;
-  float amp = 0.5;
-  for(int i = 0; i < 5; i++){
-    value += amp * noise3(p);
-    p *= 2.0;
-    amp *= 0.5;
-  }
-  return value;
-}
-
-void main(){
-  vec3 nPos = normalize(position);
-  float elevation = fbm(nPos * 5.0 + uTime * 0.1);
-  vPos = nPos;
-  vElevation = elevation;
-  vec3 displaced = nPos * (1.0 + elevation * uElevationScale);
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(displaced, 1.0);
-}
-`;
-
-const fragmentShader = `
-varying vec3 vPos;
-varying float vElevation;
-uniform float uTime;
-
-vec3 getBiomeColor(float temp, float moist){
-  if(temp < 0.3){
-    if(moist < 0.3) return vec3(0.8,0.8,0.9);
-    return vec3(0.6,0.7,0.8);
-  }
-  if(temp < 0.6){
-    if(moist < 0.3) return vec3(0.8,0.8,0.5);
-    return vec3(0.1,0.6,0.2);
-  }
-  if(moist < 0.5) return vec3(0.9,0.8,0.4);
-  return vec3(0.2,0.7,0.3);
-}
-
-void main(){
-  float temp = clamp((vPos.y + 1.0) / 2.0 + sin(vPos.x * 2.0 + uTime * 0.1) * 0.1, 0.0, 1.0);
-  float moist = clamp(0.5 + sin(vPos.z * 2.0 + uTime * 0.1) * 0.25, 0.0, 1.0);
-  vec3 color = getBiomeColor(temp, moist);
-  if(vElevation < -0.05) color = vec3(0.0, 0.3, 0.8);
-  gl_FragColor = vec4(color, 1.0);
-}
-`;
-
-const material = new THREE.ShaderMaterial({
-  vertexShader,
-  fragmentShader,
-  uniforms: {
-    uTime: { value: 0 },
-    uElevationScale: { value: 0.15 }
-  }
+const vuetify = createVuetify({
+  components,
+  directives,
 });
 
-const planet = new THREE.Mesh(geometry, material);
-scene.add(planet);
-
-const controls = new OrbitControls(camera, renderer.domElement);
-
-function resize(){
-  camera.aspect = window.innerWidth / window.innerHeight;
-  camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-}
-window.addEventListener('resize', resize);
-
-function animate(time){
-  material.uniforms.uTime.value = time * 0.001;
-  controls.update();
-  renderer.render(scene, camera);
-  requestAnimationFrame(animate);
-}
-
-animate(0);
+createApp(App).use(vuetify).mount('#app');

--- a/src/noise.js
+++ b/src/noise.js
@@ -1,8 +1,6 @@
 // Simple deterministic noise function using a seed.
 // Based on sine pseudorandom generation.
-function noise(x, seed) {
+export default function noise(x, seed) {
   const sin = Math.sin(x * seed) * 10000;
   return sin - Math.floor(sin);
 }
-
-module.exports = noise;

--- a/tests/noise.test.js
+++ b/tests/noise.test.js
@@ -1,9 +1,11 @@
-const noise = require('../src/noise');
+import noise from '../src/noise.js';
+import assert from 'assert/strict';
+import { test } from 'node:test';
 
 test('noise returns consistent values for same seed', () => {
   const seed = 42;
   const input = 1.2345;
   const first = noise(input, seed);
   const second = noise(input, seed);
-  expect(first).toBe(second);
+  assert.equal(first, second);
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vuetify from 'vite-plugin-vuetify';
+
+export default defineConfig({
+  plugins: [vue(), vuetify()]
+});


### PR DESCRIPTION
## Summary
- integrate Vue3/Vuetify build with Vite
- port Three.js logic into `PlanetViewer` Vue component
- serve built `dist` directory with Express
- update noise test for Node's `node:test`

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_684dabb9a6f08326a04366c4cdbfa7f3