### PR TITLE
Improve noise options with seedable Perlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ProceduralPlanet is an experimental project focused on generating and rendering planets procedurally using [Three.js](https://threejs.org/). The UI is built with [Vue 3](https://vuejs.org/) and [Vuetify](https://vuetifyjs.com/). The goal is to explore techniques for terrain creation, atmosphere effects and other visual features entirely through code.
 
 A detailed project description in German can be found in [docs/Projektbeschreibung.md](docs/Projektbeschreibung.md).
+See [docs/parameter_and_zoom_plan.md](docs/parameter_and_zoom_plan.md) for notes on exposing user parameters and handling zoom-based detail.
 
 ## Installation
 

--- a/docs/parameter_and_zoom_plan.md
+++ b/docs/parameter_and_zoom_plan.md
@@ -1,0 +1,37 @@
+# Plan for User Parameters and Zoom-Based Detail
+
+This document outlines how to expose planet generation parameters to the user and how to make zooming seamlessly increase surface detail.
+
+## Parameter Controls
+
+1. **UI Sliders/Inputs**
+   - Add Vuetify input components (e.g. `v-slider`, `v-text-field`) for parameters such as:
+     - Noise seed
+     - Elevation scale
+     - Noise frequency and octaves
+     - Ocean level
+   - Bind these inputs to reactive variables so changes immediately update the shader uniforms.
+
+2. **Persistence**
+   - Store current parameter values in `localStorage` to preserve settings across sessions.
+   - Optionally allow sharing a parameter preset via URL query parameters.
+
+3. **Validation and Defaults**
+   - Provide sensible default values and ranges.
+   - Validate user input to avoid unrealistic or unstable values.
+
+## Zoom-Dependent Detail
+
+1. **Adaptive Geometry**
+   - Swap the planet mesh for a version with more segments when the camera zooms in.
+   - Use `THREE.SphereGeometry` with different resolutions (e.g. 128/256/512 segments).
+
+2. **Dynamic Noise Scale**
+   - Increase the frequency of the noise functions as the camera gets closer.
+   - Update shader uniforms based on `camera.position` or current zoom distance.
+
+3. **Smooth Transitions**
+   - Fade between geometry levels or interpolate noise parameters to avoid popping artifacts.
+   - Consider using `LOD` (level of detail) helpers in Three.js for automatic switching.
+
+Implementing these steps will allow users to experiment with generation settings while ensuring that zooming reveals additional detail without noticeable transitions.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -20,3 +20,5 @@ Die folgenden Aufgaben leiten sich aus der Projektbeschreibung ab und dienen als
 - [ ] Echtzeit-Klima-Modell für Jahreszeiten
 - [ ] Export als Heightmap oder Voxelmodell
 - [ ] Rotation und Atmosphärenshell
+- [ ] Benutzerparameter (Seed, Höhenskalierung usw.) per UI einstellbar machen
+- [ ] Detailstufe des Planeten nahtlos erhöhen, wenn die Kamera heranzoomt

--- a/src/noise.js
+++ b/src/noise.js
@@ -1,6 +1,86 @@
-// Simple deterministic noise function using a seed.
-// Based on sine pseudorandom generation.
+// Basic sine‑based noise used for trivial cases.
 export default function noise(x, seed) {
   const sin = Math.sin(x * seed) * 10000;
   return sin - Math.floor(sin);
+}
+
+// Mulberry32 PRNG for deterministic permutation tables
+function mulberry32(a) {
+  return function () {
+    let t = a += 0x6D2B79F5;
+    t = Math.imul(t ^ t >>> 15, t | 1);
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+// Generate a Perlin noise object with 2D/3D functions
+export function createPerlin(seed = 1234) {
+  const rng = mulberry32(seed);
+  const p = new Uint8Array(512);
+  for (let i = 0; i < 256; i++) p[i] = i;
+  // Fisher‑Yates shuffle using the seeded RNG
+  for (let i = 255; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [p[i], p[j]] = [p[j], p[i]];
+  }
+  for (let i = 0; i < 256; i++) p[i + 256] = p[i];
+
+  const fade = t => t * t * t * (t * (t * 6 - 15) + 10);
+  const lerp = (a, b, t) => a + (b - a) * t;
+  const grad = (hash, x, y, z) => {
+    const h = hash & 15;
+    const u = h < 8 ? x : y;
+    const v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+    return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
+  };
+
+  function noise3(x, y, z) {
+    const X = Math.floor(x) & 255;
+    const Y = Math.floor(y) & 255;
+    const Z = Math.floor(z) & 255;
+    x -= Math.floor(x);
+    y -= Math.floor(y);
+    z -= Math.floor(z);
+    const u = fade(x), v = fade(y), w = fade(z);
+
+    const A = p[X] + Y, AA = p[A] + Z, AB = p[A + 1] + Z;
+    const B = p[X + 1] + Y, BA = p[B] + Z, BB = p[B + 1] + Z;
+
+    return lerp(
+      lerp(
+        lerp(grad(p[AA], x, y, z), grad(p[BA], x - 1, y, z), u),
+        lerp(grad(p[AB], x, y - 1, z), grad(p[BB], x - 1, y - 1, z), u),
+        v
+      ),
+      lerp(
+        lerp(grad(p[AA + 1], x, y, z - 1), grad(p[BA + 1], x - 1, y, z - 1), u),
+        lerp(grad(p[AB + 1], x, y - 1, z - 1), grad(p[BB + 1], x - 1, y - 1, z - 1), u),
+        v
+      ),
+      w
+    );
+  }
+
+  const noise2 = (x, y) => noise3(x, y, 0);
+
+  return { noise2, noise3 };
+}
+
+// Fractal Brownian Motion using any underlying noise3 function
+export function fbmNoise3(noiseFn, x, y, z, {
+  octaves = 4,
+  lacunarity = 2,
+  gain = 0.5
+} = {}) {
+  let value = 0;
+  let amp = 1;
+  for (let i = 0; i < octaves; i++) {
+    value += amp * noiseFn(x, y, z);
+    x *= lacunarity;
+    y *= lacunarity;
+    z *= lacunarity;
+    amp *= gain;
+  }
+  return value;
 }

--- a/tests/noise.test.js
+++ b/tests/noise.test.js
@@ -1,4 +1,4 @@
-import noise from '../src/noise.js';
+import noise, { createPerlin } from '../src/noise.js';
 import assert from 'assert/strict';
 import { test } from 'node:test';
 
@@ -8,4 +8,12 @@ test('noise returns consistent values for same seed', () => {
   const first = noise(input, seed);
   const second = noise(input, seed);
   assert.equal(first, second);
+});
+
+test('perlin noise is deterministic for identical seeds', () => {
+  const p1 = createPerlin(99);
+  const p2 = createPerlin(99);
+  const val1 = p1.noise3(0.1, 0.2, 0.3);
+  const val2 = p2.noise3(0.1, 0.2, 0.3);
+  assert.equal(val1, val2);
 });


### PR DESCRIPTION
## Summary
- expose better noise functions with a seedable Perlin implementation
- test determinism of new perlin noise
- tweak README link to the parameter plan

## Testing
- `node --test tests/noise.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684df3cba0ac8326acb63059cd1816b1