### PR TITLE
Implement deterministic feature factors

### DIFF
--- a/tests/featureOffset.test.js
+++ b/tests/featureOffset.test.js
@@ -1,0 +1,17 @@
+import { createPerlin, getFeatureFactor } from '../src/noise.js';
+import assert from 'assert/strict';
+import { test } from 'node:test';
+
+test('getFeatureFactor is deterministic for same inputs', () => {
+  const perlin = createPerlin(123);
+  const v1 = getFeatureFactor(perlin, 42, 'layer', 0, 'radius');
+  const v2 = getFeatureFactor(perlin, 42, 'layer', 0, 'radius');
+  assert.equal(v1, v2);
+});
+
+test('different parameter tag results in different values', () => {
+  const perlin = createPerlin(123);
+  const v1 = getFeatureFactor(perlin, 42, 'layer', 0, 'a');
+  const v2 = getFeatureFactor(perlin, 42, 'layer', 0, 'b');
+  assert.notEqual(v1, v2);
+});


### PR DESCRIPTION
## Summary
- extend Perlin noise generator with `noise1`
- add global offset helpers for deterministic feature factors
- add tests for feature offsets

## Testing
- `node --test tests/*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684e8ce5dfb083269073d50e23ab3ef0